### PR TITLE
Performance update

### DIFF
--- a/addon-WhoReplied.xml
+++ b/addon-WhoReplied.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<addon addon_id="WhoReplied" title="Who Replied" version_string="1.3.0b" version_id="7" url="http://xenforo.com/community/resources/who-replied.1537/" install_callback_class="" install_callback_method="" uninstall_callback_class="" uninstall_callback_method="">
+<addon addon_id="WhoReplied" title="Who Replied" version_string="1.4.0" version_id="8" url="http://xenforo.com/community/resources/who-replied.1537/" install_callback_class="" install_callback_method="" uninstall_callback_class="" uninstall_callback_method="">
   <admin_navigation/>
   <admin_permissions/>
   <admin_style_properties/>

--- a/upload/library/WhoReplied/Model/WhoReplied.php
+++ b/upload/library/WhoReplied/Model/WhoReplied.php
@@ -9,18 +9,19 @@ class WhoReplied_Model_WhoReplied extends XenForo_Model
 	 */
 	public function getUserAndCountPosts($thread)
 	{
-		return $this->fetchAllKeyed("
-						SELECT COUNT(posts.post_id) as post_count, user.*
-							FROM xf_post as posts
-						INNER JOIN xf_user AS user
-							ON user.user_id = posts.user_id
-						WHERE posts.thread_id = '". $thread['thread_id'] . "' AND
-							  posts.position <> 0 AND
-							  posts.message_state ='visible'
-						GROUP BY user.user_id
-						ORDER BY post_count DESC
-						"
-				, "user_id");
+        $users = $this->fetchAllKeyed("
+            SELECT post_count, user.*
+            FROM xf_thread_user_post posts
+            JOIN xf_user user ON user.user_id = posts.user_id
+            WHERE posts.thread_id = '". $thread['thread_id'] . "'
+            ORDER BY post_count DESC
+            ", "user_id");
+        // remove the first post from the post count
+        if (isset($users[$thread['user_id']]))
+        {
+            $users[$thread['user_id']]['post_count'] = $users[$thread['user_id']]['post_count'] - 1;
+        }
+		return $users;
 	}
 
 


### PR DESCRIPTION
XenForo has the table xf_thread_user_post which contains  a cached copy of a user's post count in a thread.

This table is automatically managed, and updated on moderation actions.

Using this table, allows the query against a thread with 58803 posts, and 692 users to take ~0.3 seconds vs ~5 seconds (or 11 seconds with a cold DB cache)